### PR TITLE
* Add psycopg2 requirement necessary for running migrations on a post…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ node_modules
 # ignore secure.py
 secure.py
 
+# Ignore sqlite dbs
+*.sqlite3
+
+

--- a/canvas_syllabus_export/requirements/aws.txt
+++ b/canvas_syllabus_export/requirements/aws.txt
@@ -1,7 +1,8 @@
 git+https://github.com/penzance/canvas_python_sdk@master#egg=canvas_python_sdk==0.7.7
-Django == 1.8.2
-python_dateutil == 2.4.2
+Django==1.8.2
+python_dateutil==2.4.2
 redis==2.10.3
 django-redis-cache==1.1.1
 git+https://github.com/Harvard-ATG/django-app-lti@master#egg=django-app-lti==1.0
 git+https://github.com/Harvard-University-iCommons/django-auth-lti@master#egg=django-auth-lti==v1.2.1
+psycopg2==2.6.1

--- a/canvas_syllabus_export/settings/aws.py
+++ b/canvas_syllabus_export/settings/aws.py
@@ -17,7 +17,7 @@ from .secure import SECURE_SETTINGS
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Base URL for Canvas instance
-BASE_URL = SECURE_SETTINGS.get('base_url',"https://canvas.harvard.edu/api")
+BASE_URL = SECURE_SETTINGS.get('base_url', "https://canvas.harvard.edu/api")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
@@ -143,9 +143,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 STATIC_ROOT = os.path.normpath(os.path.join(BASE_DIR, 'http_static'))
 STATIC_URL = '/static/'
-STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, 'syllabuspdf', 'static'),
-)
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
@@ -226,4 +223,3 @@ LOGGING = {
         }
     }
 }
-


### PR DESCRIPTION
…gres db.

* Remove STATICFILES_DIRS setting since by default the STATICFILES_FINDERS (https://docs.djangoproject.com/en/1.8/ref/settings/#staticfiles-finders) will look for a /static subdirectory in any included apps

@xueharry 
@arthurian 